### PR TITLE
Respect exclude without requiring restart

### DIFF
--- a/.vscode/dev.code-snippets
+++ b/.vscode/dev.code-snippets
@@ -1,0 +1,38 @@
+{
+	// Place ahk2-lsp workspace snippets here.
+	// Each snippet is defined under a snippet name and has a scope, prefix, body and description.
+	// Add comma-separated IDs of the languages where the snippet is applicable in the scope field.
+	// If scope is left empty or omitted, the snippet gets applied to all languages.
+	// The prefix is what is used to trigger the snippet and the body will be expanded and inserted.
+	// Possible variables are: $1, $2 for tab stops, $0 for the final cursor position,
+	// and ${1:label}, ${2:another} for placeholders.
+	// Placeholders with the same IDs are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+	"Mocha tuple tests": {
+		"scope": "javascript,typescript",
+		"prefix": "suite",
+		"body": [
+			"suite('$1', () => {",
+			"    const tests: [",
+			"        name: string,",
+			"        args: Parameters<typeof $1>,",
+			"        expected: ReturnType<typeof $1>,",
+			"    ][] = [$0];",
+
+			"    tests.forEach(([name, args, expected]) =>",
+			"        test(name, () => assert.strictEqual($1(...args), expected)),",
+			"    );",
+			"});",
+		],
+		"description": "Generate tests for Mocha.",
+	},
+}

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "AHK++ (AutoHotkey Plus Plus)",
+			"title": "AHK++ v2 support",
 			"properties": {
 				"AHK++.compiler": {
 					"type": "object",

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,7 +22,7 @@
 	"ahk++.config.v2.diagnostics.classNonDynamicMemberCheck": "Check whether non-dynamic members of a class exist",
 	"ahk++.config.v2.diagnostics.paramsCheck": "Check that the function call has the correct number of arguments",
 	"ahk++.config.v2.file.interpreterPath": "Path to the `AutoHotkey.exe` executable file for AHK v2.",
-	"ahk++.config.exclude": "⚠️ Not yet supported, ref [issue #488](https://github.com/mark-wiemer-org/ahkpp/issues/488).\n\nGlob patterns for excluding files and folders when scanning AHK files.",
+	"ahk++.config.exclude": "[Glob patterns](<https://en.wikipedia.org/wiki/Glob_(programming)>) for excluding files and folders from completion suggestions. Applies even when files are opened.",
 	"ahk++.config.v2.file.maxScanDepth": "Depth of folders to scan for IntelliSense. Negative values mean infinite depth.",
 	"ahk++.config.v2.librarySuggestions": "Which libraries to suggest functions from, if any. In case of issues, restart your IDE.",
 	"ahk++.config.v2.symbolFoldingFromOpenBrace": "Fold parameter lists separately from definitions.",

--- a/server/src/common.ts
+++ b/server/src/common.ts
@@ -192,6 +192,7 @@ export function initahk2cache() {
 /** Loads IntelliSense hover text */
 export function loadAHK2(filename = 'ahk2', d = 3) {
 	let path: string | undefined;
+	/** Path to included syntax files, with `<>` replacing the locale */
 	const file = `${rootdir}/syntaxes/<>/${filename}`;
 	if (process.env.BROWSER) {
 		const td = openFile(file + '.d.ahk');
@@ -208,7 +209,12 @@ export function loadAHK2(filename = 'ahk2', d = 3) {
 	} else {
 		const syntaxConfig = getCfg(CfgKey.Syntaxes);
 		const syntaxes = syntaxConfig && existsSync(syntaxConfig) ? syntaxConfig : '';
-		const file2 = syntaxes ? `${syntaxes}/<>/${filename}` : file;
+		/**
+		 * Path to syntax files to load,
+		 * either chosen by user or included with extension,
+		 * with `<>` replacing the locale
+		 */
+		const syntaxFilesToLoad = syntaxes ? `${syntaxes}/<>/${filename}` : file;
 		let td: TextDocument | undefined;
 		if ((path = getfilepath('.d.ahk')) && (td = openFile(restorePath(path)))) {
 			const doc = new Lexer(td, undefined, d);
@@ -226,7 +232,7 @@ export function loadAHK2(filename = 'ahk2', d = 3) {
 				}
 		}
 		function getfilepath(ext: string) {
-			return getlocalefilepath(file2 + ext) || (file2 !== file ? getlocalefilepath(file + ext) : undefined);
+			return getlocalefilepath(syntaxFilesToLoad + ext) || (syntaxFilesToLoad !== file ? getlocalefilepath(file + ext) : undefined);
 		}
 	}
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -396,8 +402,8 @@ export function updateConfig(newConfig: AHKLSConfig): void {
 			}
 		globalScanExclude.file = file;
 		globalScanExclude.folder = folder;
-		console.log(`Excluded files: ${globalScanExclude.file?.map(re => re.source).join('\n') ?? '(none)'}`);
-		console.log(`Excluded folders: ${globalScanExclude.folder?.map(re => re.source).join('\n') ?? '(none)'}`);
+		console.log(`Excluded files:\n\t${globalScanExclude.file.map(re => re.source).join('\n\t') || '(none)'}`);
+		console.log(`Excluded folders\n\t ${globalScanExclude.folder.map(re => re.source).join('\n\t') || '(none)'}`);
 		let maxScanDepth = getCfg<number | undefined>(CfgKey.MaxScanDepth, newConfig);
 		if (maxScanDepth === undefined) {
 			maxScanDepth = 2;

--- a/server/src/lexer.ts
+++ b/server/src/lexer.ts
@@ -26,6 +26,7 @@ import {
 	restorePath, rootdir, setTextDocumentLanguage, symbolProvider, utils, workspaceFolders
 } from './common';
 import { ActionType, BlockStyle, BraceStyle, CallWithoutParentheses, CfgKey, FormatOptions, getCfg } from '../../util/src/config';
+import { shouldExclude } from '../../util/src/exclude';
 
 export interface ParamInfo {
 	offset: number
@@ -6623,6 +6624,7 @@ export function parse_include(lex: Lexer, dir: string, _set = new Set()) {
 	_set.add(lex);
 	for (const uri in include) {
 		const path = include[uri];
+		if (shouldExclude(path)) continue;
 		let lex, t;
 		if (!(lex = lexers[uri])) {
 			if (!existsSync(path) || !(t = openFile(restorePath(path))))

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -204,7 +204,9 @@ documents.onDidOpen(e => {
 	const uri = e.document.uri.toLowerCase();
 	let lexer = lexers[uri];
 	// don't add excluded documents
-	if (globalScanExclude.file?.some(re => re.test(e.document.uri))) {
+	if (globalScanExclude.folder?.some(re => re.test(e.document.uri))
+		|| globalScanExclude.file?.some(re => re.test(e.document.uri)))
+	{
 		console.log(`Skipping: ${e.document.uri}`);
 		return;
 	}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -164,16 +164,17 @@ connection.onDidChangeConfiguration(async change => {
 	// clone the old config to compare
 	const oldConfig = klona(getCfg<AHKLSConfig>());
 	updateConfig(newConfig); // this updates the object in-place, hence the clone above
+	const excludeChanged = getCfg(CfgKey.Exclude) !== getCfg(CfgKey.Exclude, oldConfig);
 	set_WorkspaceFolders(workspaceFolders);
 	const newInterpreterPath = getCfg(CfgKey.InterpreterPath);
 	if (newInterpreterPath !== getCfg(CfgKey.InterpreterPath, oldConfig)) {
 		if (await setInterpreter(resolvePath(newInterpreterPath)))
 			connection.sendRequest(clientUpdateStatusBar, [newInterpreterPath]);
 	}
-	if (getCfg(CfgKey.LibrarySuggestions) !== getCfg(CfgKey.LibrarySuggestions, oldConfig)) {
-		if (shouldIncludeUserStdLib() && !shouldIncludeUserStdLib(oldConfig))
+	if (excludeChanged || getCfg(CfgKey.LibrarySuggestions) !== getCfg(CfgKey.LibrarySuggestions, oldConfig)) {
+		if (shouldIncludeUserStdLib() && (excludeChanged || !shouldIncludeUserStdLib(oldConfig)))
 			parseuserlibs();
-		if (shouldIncludeLocalLib() && !shouldIncludeLocalLib(oldConfig))
+		if (shouldIncludeLocalLib() && (excludeChanged || !shouldIncludeLocalLib(oldConfig)))
 			documents.all().forEach(e => parseproject(e.uri.toLowerCase()));
 	}
 	if (getCfg(CfgKey.Syntaxes) !== getCfg(CfgKey.Syntaxes, oldConfig)) {

--- a/util/src/config.ts
+++ b/util/src/config.ts
@@ -225,6 +225,7 @@ export const configPrefix = 'AHK++';
 /**
  * Gets a single config value from the provided config.
  * If no config provided, uses the global config.
+ * If no key provided, returns the entire config.
  */
 export const getCfg = <T = string>(
 	key?: CfgKey,

--- a/util/src/exclude.spec.ts
+++ b/util/src/exclude.spec.ts
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import { suite, test } from 'mocha';
+import { shouldExclude } from './exclude';
+
+suite('shouldExclude', () => {
+	const tests: [
+		name: string,
+		args: Parameters<typeof shouldExclude>,
+		expected: ReturnType<typeof shouldExclude>,
+	][] = [
+		['include file', ['file', 'all', { file: [], folder: [] }], false],
+		['include folder', ['folder', 'all', { file: [], folder: [] }], false],
+		[
+			'exclude folder',
+			['folder', 'folderOnly', { file: [], folder: [/folder/i] }],
+			true,
+		],
+		['exclude file', ['file', 'all', { file: [/file/i], folder: [] }], true],
+		[
+			`include folder that matches file pattern`,
+			['folder', 'folderOnly', { file: [/file/i], folder: [] }],
+			false,
+		],
+		[
+			`exclude file that matches folder pattern`,
+			['folder/file', 'all', { file: [], folder: [/folder/i] }],
+			true,
+		],
+	];
+	tests.forEach(([name, args, expected]) =>
+		test(name, () => assert.strictEqual(shouldExclude(...args), expected)),
+	);
+});

--- a/util/src/exclude.ts
+++ b/util/src/exclude.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'path';
-
 /** The regular expressions to check for exclusion */
 export interface ScanExclude {
 	file: RegExp[];
@@ -9,8 +7,8 @@ export interface ScanExclude {
 export const globalScanExclude: ScanExclude = { file: [], folder: [] };
 
 /**
- * Resolves the provided path and
- * returns whether it should be excluded from scanning based on its name.
+ * Returns whether the provided path should be excluded from scanning based on its name.
+ * Assumes the path is already resolved.
  */
 export const shouldExclude = (
 	path: string,
@@ -19,11 +17,10 @@ export const shouldExclude = (
 	/** The patterns to use for exclusion testing. Defaults to global patterns, matching user settings */
 	exclude: ScanExclude = globalScanExclude,
 ): boolean => {
-	const resolvedPath = resolve(path);
-	if (exclude.folder.some((re) => re.test(resolvedPath))) {
+	if (exclude.folder.some((re) => re.test(path))) {
 		return true;
 	}
-	if (options === 'all' && exclude.file.some((re) => re.test(resolvedPath))) {
+	if (options === 'all' && exclude.file.some((re) => re.test(path))) {
 		return true;
 	}
 	return false;

--- a/util/src/exclude.ts
+++ b/util/src/exclude.ts
@@ -1,0 +1,30 @@
+import { resolve } from 'path';
+
+/** The regular expressions to check for exclusion */
+export interface ScanExclude {
+	file: RegExp[];
+	folder: RegExp[];
+}
+
+export const globalScanExclude: ScanExclude = { file: [], folder: [] };
+
+/**
+ * Resolves the provided path and
+ * returns whether it should be excluded from scanning based on its name.
+ */
+export const shouldExclude = (
+	path: string,
+	/** Folder only will check only the folder patterns in the provided exclude object */
+	options: 'folderOnly' | 'all' = 'all',
+	/** The patterns to use for exclusion testing. Defaults to global patterns, matching user settings */
+	exclude: ScanExclude = globalScanExclude,
+): boolean => {
+	const resolvedPath = resolve(path);
+	if (exclude.folder.some((re) => re.test(resolvedPath))) {
+		return true;
+	}
+	if (options === 'all' && exclude.file.some((re) => re.test(resolvedPath))) {
+		return true;
+	}
+	return false;
+};


### PR DESCRIPTION
- Check exclusion setting whenever relevant, instead of relying on extension restart
- Exclude files even when they're opened or added via `#include` for consistency of UX
- New code snippets for Mocha tuple tests
- Improved logs for excluded files and completion provider